### PR TITLE
Vercel Data Cache - Middleware Adapter

### DIFF
--- a/core/app/api/temp-cache-headers/route.ts
+++ b/core/app/api/temp-cache-headers/route.ts
@@ -1,0 +1,11 @@
+import { credentialsFromFetch } from '~/lib/vdc/credentials-from-fetch';
+
+export async function GET(request: Request) {
+  const data = await credentialsFromFetch(request.headers);
+
+  return new Response(JSON.stringify(data), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/core/lib/kv/adapters/vercel-data-cache.ts
+++ b/core/lib/kv/adapters/vercel-data-cache.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from 'next/server';
+
+import { getComputeCache } from '~/lib/vdc';
+
+import { KvAdapter, SetCommandOptions } from '../types';
+
+export class VercelDataCacheAdapter implements KvAdapter {
+  private request?: NextRequest;
+
+  setRequest(request: NextRequest) {
+    this.request = request;
+  }
+
+  async mget<Data>(...keys: string[]) {
+    const computeCache = await getComputeCache<Data>(this.request);
+
+    const values = await Promise.all(
+      keys.map(async (key) => {
+        const value = await computeCache.get(key);
+
+        return value ?? null;
+      }),
+    );
+
+    return values;
+  }
+
+  async set<Data>(key: string, value: Data, opts?: SetCommandOptions) {
+    const computeCache = await getComputeCache<Data>(this.request);
+
+    // expiryTime is in milliseconds, so we need to convert it to seconds
+    const revalidate = opts?.expiryTime ? Number(opts.expiryTime) / 1000 : 0;
+
+    const response = await computeCache.set(key, value, { revalidate });
+
+    if (response === 'OK') {
+      return null;
+    }
+
+    return response;
+  }
+}

--- a/core/lib/kv/types.ts
+++ b/core/lib/kv/types.ts
@@ -1,6 +1,9 @@
+import { NextRequest } from 'next/server';
+
 export type SetCommandOptions = Record<string, unknown>;
 
 export interface KvAdapter {
+  setRequest?: (request: NextRequest) => void;
   mget<Data>(...keys: string[]): Promise<Array<Data | null>>;
   set<Data>(key: string, value: Data, opts?: SetCommandOptions): Promise<Data | null>;
 }

--- a/core/lib/vdc/credentials-from-fetch.ts
+++ b/core/lib/vdc/credentials-from-fetch.ts
@@ -1,0 +1,65 @@
+/* eslint-disable no-async-promise-executor */
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-base-to-string */
+/* eslint-disable @typescript-eslint/no-misused-promises */
+export async function credentialsFromFetch(headers: Headers) {
+  return new Promise<Record<string, string>>(async (resolve, reject) => {
+    if (process.env.NODE_ENV !== 'production') {
+      resolve({});
+
+      return;
+    }
+
+    const host = headers.get('x-vercel-sc-host');
+
+    if (!host) {
+      reject(new Error('Missing x-vercel-sc-host header'));
+    }
+
+    const basepath = headers.get('x-vercel-sc-basepath');
+    const original = globalThis.fetch;
+    const sentinelUrl = `https://vercel.com/robots.txt?id=${Math.random()}`;
+
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      if (!input.toString().startsWith(`https://${host}/`)) {
+        return original(input, init);
+      }
+
+      const h = new Headers(init?.headers);
+      const url = h.get('x-vercel-cache-item-name');
+
+      if (url !== sentinelUrl) {
+        return original(input, init);
+      }
+
+      console.log('h', input, url, h);
+
+      const authorization = h.get('authorization');
+
+      if (!authorization) {
+        reject(new Error('Missing cache authorization header'));
+      }
+
+      resolve({
+        'x-vercel-sc-headers': JSON.stringify({
+          authorization: h.get('authorization'),
+        }),
+        'x-vercel-sc-host': host || '',
+        'x-vercel-sc-basepath': basepath || '',
+      });
+      globalThis.fetch = original;
+
+      return new Response(JSON.stringify({}), {
+        status: 510,
+      });
+    };
+
+    try {
+      await fetch(sentinelUrl, {
+        cache: 'force-cache',
+      });
+    } catch (e) {
+      console.info(e);
+    }
+  });
+}

--- a/core/lib/vdc/in-memory-cache.ts
+++ b/core/lib/vdc/in-memory-cache.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+/* eslint-disable max-classes-per-file */
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+/* eslint-disable @typescript-eslint/require-await */
+import { CacheHandler, CacheHandlerValue, IncrementalCacheValue, Revalidate } from './types';
+
+let instance: InMemoryCacheHandlerInternal;
+
+interface SetContext {
+  revalidate?: Revalidate;
+  fetchCache?: boolean;
+  fetchUrl?: string;
+  fetchIdx?: number;
+  tags?: string[];
+  isRoutePPREnabled?: boolean;
+  isFallback?: boolean;
+}
+
+export class InMemoryCacheHandler implements CacheHandler {
+  constructor() {
+    instance = instance ?? new InMemoryCacheHandlerInternal();
+  }
+  get(key: string) {
+    return instance.get(key);
+  }
+  set(key: string, data: IncrementalCacheValue | null, ctx: SetContext) {
+    return instance.set(key, data, ctx);
+  }
+  revalidateTag(tags: string | string[]) {
+    return instance.revalidateTag(tags);
+  }
+  resetRequestCache() {
+    instance.resetRequestCache();
+  }
+}
+
+class InMemoryCacheHandlerInternal implements CacheHandler {
+  readonly cache: Map<
+    string,
+    {
+      value: string;
+      lastModified: number;
+      tags: string[];
+      revalidate: number | undefined;
+    }
+  >;
+
+  constructor() {
+    this.cache = new Map();
+  }
+
+  async get(key: string): Promise<CacheHandlerValue | null> {
+    const content = this.cache.get(key);
+
+    if (content?.revalidate && content.lastModified + content.revalidate * 1000 < Date.now()) {
+      this.cache.delete(key);
+
+      return null;
+    }
+
+    if (content) {
+      return {
+        value: JSON.parse(content.value) as IncrementalCacheValue | null,
+        lastModified: content.lastModified,
+        age: Date.now() - content.lastModified,
+      };
+    }
+
+    return null;
+  }
+
+  async set(key: string, data: IncrementalCacheValue | null, ctx: SetContext) {
+    // This could be stored anywhere, like durable storage
+    this.cache.set(key, {
+      value: JSON.stringify(data),
+      lastModified: Date.now(),
+      tags: ctx.tags || [],
+      revalidate: ctx.revalidate ? ctx.revalidate : undefined,
+    });
+  }
+
+  async revalidateTag(tag: string | string[]) {
+    const tags = [tag].flat();
+
+    // Iterate over all entries in the cache
+    for (const [key, value] of this.cache) {
+      // If the value's tags include the specified tag, delete this entry
+      if (value.tags.some((tag: string) => tags.includes(tag))) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  resetRequestCache() {}
+}

--- a/core/lib/vdc/index.ts
+++ b/core/lib/vdc/index.ts
@@ -1,0 +1,205 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-confusing-void-expression */
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable no-multi-assign */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { InMemoryCacheHandler } from './in-memory-cache';
+import { CachedRouteKind, CacheHandler, CacheHandlerContext, IncrementalCacheKind } from './types';
+
+export interface ComputeCache<T> {
+  get: (key: string) => Promise<T | undefined>;
+  set: (
+    key: string,
+    value: any,
+    options?: { tags?: string[]; revalidate?: number },
+  ) => Promise<void>;
+  revalidateTag: (tag: string) => Promise<void>;
+}
+
+export async function getComputeCache<T>(
+  requestHeadersOverride?: Record<string, string | string[] | undefined> | Request | Headers,
+): Promise<ComputeCache<T>> {
+  const requestHeaders = await getCacheHeaders(getHeadersRecord(requestHeadersOverride));
+
+  console.log('requestHeaders', JSON.stringify(requestHeaders));
+
+  const internalCache = new FetchCacheConstructor({
+    fetchCacheKeyPrefix: 'compute-cache',
+    revalidatedTags: [],
+    // Constructor deletes the headers, so we need to clone them
+    _requestHeaders: Object.assign({}, requestHeaders) as Record<string, string>,
+    maxMemoryCacheSize: 0,
+  });
+
+  internalCache.resetRequestCache();
+
+  return {
+    get: async (key: string): Promise<T | undefined> => {
+      const fullKey = getKey(key);
+      const content = await internalCache.get(fullKey, {
+        kind: IncrementalCacheKind.FETCH,
+        isFallback: false,
+        fetchUrl: `https://vercel.cache/${fullKey}`,
+      });
+
+      if (content) {
+        console.log('get', fullKey, content);
+
+        const lastModified = content.lastModified;
+        const revalidate = content.value?.revalidate;
+
+        if (revalidate && lastModified && lastModified + revalidate * 1000 < Date.now()) {
+          internalCache.resetRequestCache();
+
+          return;
+        }
+
+        const value = content.value;
+
+        if (!value) {
+          return;
+        }
+
+        return JSON.parse(value.data.body);
+      }
+    },
+    set: async (key: string, value: any, options?: { tags?: string[]; revalidate?: number }) => {
+      const fullKey = getKey(key);
+      const r = await internalCache.set(
+        fullKey,
+        {
+          kind: CachedRouteKind.FETCH,
+          data: {
+            headers: {},
+            body: JSON.stringify(value),
+            url: `https://vercel.cache/${fullKey}`,
+            status: 200,
+          },
+          // Magic tag for forever
+          revalidate: options?.revalidate ?? 0xfffffffe,
+        },
+        {
+          fetchCache: true,
+          fetchUrl: `https://vercel.cache/${fullKey}`,
+          revalidate: options?.revalidate,
+          isFallback: false,
+          tags: options?.tags,
+        },
+      );
+
+      console.log('set', fullKey, value, {
+        fetchCache: true,
+        fetchUrl: `https://vercel.cache/${fullKey}`,
+        revalidate: options?.revalidate,
+        isFallback: false,
+        tags: options?.tags,
+      });
+
+      // Temp hack. For some reason we cannot turn off the in-memory cache.
+      if (options?.revalidate) {
+        internalCache.resetRequestCache();
+      }
+
+      return r;
+    },
+    revalidateTag: (tag: string | string[]) => {
+      const r = internalCache.revalidateTag(tag);
+
+      internalCache.resetRequestCache();
+
+      return r;
+    },
+  } as const;
+}
+
+function getHeadersRecord(
+  requestHeadersOverride:
+    | Record<string, string | string[] | undefined>
+    | Request
+    | Headers
+    | undefined,
+): Record<string, string | string[] | undefined> | undefined {
+  if (!requestHeadersOverride) {
+    return undefined;
+  }
+
+  if (requestHeadersOverride instanceof Headers) {
+    return Object.fromEntries([...requestHeadersOverride.entries()]);
+  }
+
+  if (requestHeadersOverride instanceof Request) {
+    return Object.fromEntries([...requestHeadersOverride.headers.entries()]);
+  }
+
+  return requestHeadersOverride;
+}
+
+let FetchCacheConstructor: new (ctx: CacheHandlerContext) => CacheHandler;
+
+initializeComputeCache();
+
+export function initializeComputeCache() {
+  const cacheHandlersSymbol = Symbol.for('@next/cache-handlers');
+  const _globalThis: typeof globalThis & {
+    [cacheHandlersSymbol]?: {
+      FetchCache?: new (ctx: CacheHandlerContext) => CacheHandler;
+    };
+  } = globalThis;
+  const cacheHandlers = (_globalThis[cacheHandlersSymbol] ??= {});
+  let { FetchCache } = cacheHandlers;
+
+  if (!FetchCache) {
+    FetchCache = InMemoryCacheHandler;
+
+    if (process.env.NODE_ENV === 'production') {
+      console.error('Cache handler not found');
+    }
+  }
+
+  FetchCacheConstructor = FetchCache;
+}
+
+let cacheHeaders: Promise<Record<string, string>> | undefined;
+
+async function getCacheHeadersFromDeployedFunction() {
+  const r = await fetch(`https://${process.env.VERCEL_URL}/api/temp-cache-headers`, {
+    cache: 'no-store',
+    headers: {
+      'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '',
+    },
+  });
+
+  if (!r.ok) {
+    cacheHeaders = undefined;
+    throw new Error('Failed to fetch cache headers');
+  }
+
+  return r.json();
+}
+
+async function getCacheHeaders(
+  requestHeaders?: Record<string, string | string[] | undefined>,
+): Promise<Record<string, string | string[] | undefined>> {
+  if (process.env.NODE_ENV !== 'production') {
+    return {};
+  }
+
+  if (cacheHeaders) {
+    return cacheHeaders;
+  }
+
+  if (requestHeaders?.['x-vercel-sc-headers']) {
+    return requestHeaders;
+  }
+
+  cacheHeaders = getCacheHeadersFromDeployedFunction();
+
+  return cacheHeaders;
+}
+
+function getKey(key: string) {
+  return `compute-cache/${process.env.VERCEL_ENV || 'development'}/${key}`;
+}

--- a/core/lib/vdc/index.ts
+++ b/core/lib/vdc/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-/* eslint-disable @typescript-eslint/no-confusing-void-expression */
+
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable no-multi-assign */
@@ -11,11 +11,7 @@ import { CachedRouteKind, CacheHandler, CacheHandlerContext, IncrementalCacheKin
 
 export interface ComputeCache<T> {
   get: (key: string) => Promise<T | undefined>;
-  set: (
-    key: string,
-    value: any,
-    options?: { tags?: string[]; revalidate?: number },
-  ) => Promise<void>;
+  set: (key: string, value: any, options?: { tags?: string[]; revalidate?: number }) => Promise<T>;
   revalidateTag: (tag: string) => Promise<void>;
 }
 
@@ -68,7 +64,8 @@ export async function getComputeCache<T>(
     },
     set: async (key: string, value: any, options?: { tags?: string[]; revalidate?: number }) => {
       const fullKey = getKey(key);
-      const r = await internalCache.set(
+
+      await internalCache.set(
         fullKey,
         {
           kind: CachedRouteKind.FETCH,
@@ -103,7 +100,7 @@ export async function getComputeCache<T>(
         internalCache.resetRequestCache();
       }
 
-      return r;
+      return value;
     },
     revalidateTag: (tag: string | string[]) => {
       const r = internalCache.revalidateTag(tag);

--- a/core/lib/vdc/types.ts
+++ b/core/lib/vdc/types.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+export interface CacheHandler {
+  get(
+    _cacheKey: string,
+    _ctx: {
+      kind: IncrementalCacheKind;
+      revalidate?: Revalidate;
+      fetchUrl?: string;
+      fetchIdx?: number;
+      tags?: string[];
+      softTags?: string[];
+      isRoutePPREnabled?: boolean;
+      isFallback: boolean | undefined;
+    },
+  ): Promise<CacheHandlerValue | null>;
+
+  set(
+    cacheKey: string,
+    entry: IncrementalCacheValue,
+    ctx: {
+      revalidate?: Revalidate;
+      fetchCache?: boolean;
+      fetchUrl?: string;
+      fetchIdx?: number;
+      tags?: string[];
+      isRoutePPREnabled?: boolean;
+      isFallback?: boolean;
+    },
+  ): Promise<void>;
+
+  revalidateTag(tags: string | string[]): Promise<void>;
+
+  resetRequestCache(): void;
+}
+
+type CachedFetchData = {
+  headers: Record<string, string>;
+  body: string;
+  url: string;
+  status?: number;
+};
+
+export interface IncrementalCacheValue {
+  kind: CachedRouteKind.FETCH;
+  data: CachedFetchData;
+  // tags are only present with file-system-cache
+  // fetch cache stores tags outside of cache entry
+  tags?: string[];
+  revalidate: number;
+}
+
+export enum CachedRouteKind {
+  APP_PAGE = 'APP_PAGE',
+  APP_ROUTE = 'APP_ROUTE',
+  PAGES = 'PAGES',
+  FETCH = 'FETCH',
+  REDIRECT = 'REDIRECT',
+  IMAGE = 'IMAGE',
+}
+
+export enum IncrementalCacheKind {
+  APP_PAGE = 'APP_PAGE',
+  APP_ROUTE = 'APP_ROUTE',
+  PAGES = 'PAGES',
+  FETCH = 'FETCH',
+  IMAGE = 'IMAGE',
+}
+
+export interface CacheHandlerValue {
+  lastModified?: number;
+  age?: number;
+  cacheState?: string;
+  value: IncrementalCacheValue | null;
+}
+
+export interface CacheHandlerContext {
+  dev?: boolean;
+  flushToDisk?: boolean;
+  serverDistDir?: string;
+  maxMemoryCacheSize?: number;
+  fetchCacheKeyPrefix?: string;
+  prerenderManifest?: Record<string, unknown>;
+  revalidatedTags: string[];
+  _requestHeaders: Record<string, string>;
+}
+
+export type Revalidate = number | false;

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -6,8 +6,9 @@ import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { kvKey, STORE_STATUS_KEY } from '~/lib/kv/keys';
+import { KvAdapter } from '~/lib/kv/types';
 
-import { kv } from '../lib/kv';
+import { createKV, KV } from '../lib/kv';
 
 import { type MiddlewareFactory } from './compose-middlewares';
 
@@ -169,6 +170,7 @@ const updateRouteCache = async (
   pathname: string,
   channelId: string,
   event: NextFetchEvent,
+  kv: KV<KvAdapter>,
 ): Promise<RouteCache> => {
   const routeCache: RouteCache = {
     route: await getRoute(pathname, channelId),
@@ -183,6 +185,7 @@ const updateRouteCache = async (
 const updateStatusCache = async (
   channelId: string,
   event: NextFetchEvent,
+  kv: KV<KvAdapter>,
 ): Promise<StorefrontStatusCache> => {
   const status = await getStoreStatus(channelId);
 
@@ -208,7 +211,7 @@ const clearLocaleFromPath = (path: string, locale: string) => {
   return path;
 };
 
-const getRouteInfo = async (request: NextRequest, event: NextFetchEvent) => {
+const getRouteInfo = async (request: NextRequest, event: NextFetchEvent, kv: KV<KvAdapter>) => {
   const locale = request.headers.get('x-bc-locale') ?? '';
   const channelId = request.headers.get('x-bc-channel-id') ?? '';
 
@@ -223,15 +226,15 @@ const getRouteInfo = async (request: NextRequest, event: NextFetchEvent) => {
     // If caches are old, update them in the background and return the old data (SWR-like behavior)
     // If cache is missing, update it and return the new data, but write to KV in the background
     if (statusCache && statusCache.expiryTime < Date.now()) {
-      event.waitUntil(updateStatusCache(channelId, event));
+      event.waitUntil(updateStatusCache(channelId, event, kv));
     } else if (!statusCache) {
-      statusCache = await updateStatusCache(channelId, event);
+      statusCache = await updateStatusCache(channelId, event, kv);
     }
 
     if (routeCache && routeCache.expiryTime < Date.now()) {
-      event.waitUntil(updateRouteCache(pathname, channelId, event));
+      event.waitUntil(updateRouteCache(pathname, channelId, event, kv));
     } else if (!routeCache) {
-      routeCache = await updateRouteCache(pathname, channelId, event);
+      routeCache = await updateRouteCache(pathname, channelId, event, kv);
     }
 
     const parsedRoute = RouteCacheSchema.safeParse(routeCache);
@@ -254,9 +257,10 @@ const getRouteInfo = async (request: NextRequest, event: NextFetchEvent) => {
 
 export const withRoutes: MiddlewareFactory = () => {
   return async (request, event) => {
+    const kv = createKV(request);
     const locale = request.headers.get('x-bc-locale') ?? '';
 
-    const { route, status } = await getRouteInfo(request, event);
+    const { route, status } = await getRouteInfo(request, event, kv);
 
     if (status === 'MAINTENANCE') {
       // 503 status code not working - https://github.com/vercel/next.js/issues/50155


### PR DESCRIPTION
This pull request adds a Vercel Data Cache adapter to Catalyst.

### Data Cache Enhancements:

* Added a new `VercelDataCacheAdapter` class to handle caching with Vercel's data cache, including methods for setting and getting cache values (`core/lib/kv/adapters/vercel-data-cache.ts`).
* Introduced the core vdc lib and `getComputeCache` function to manage cache operations, including fetching and setting cache values with headers and revalidation (`core/lib/vdc/index.ts`).

### KV Adapter Modifications:

* Modified the `KV` class to accept a `NextRequest` object and set it via the `setRequest` method. This allows the KV adapter to handle requests (`core/lib/kv/index.ts`). [[1]](diffhunk://#diff-b1410a54099d56f70b523df52ab2172d91508381035e573612d7ad5316407681L10-R28) [[2]](diffhunk://#diff-b1410a54099d56f70b523df52ab2172d91508381035e573612d7ad5316407681R84-R87)
* Updated the `createKVAdapter` function to conditionally return the `VercelDataCacheAdapter` based on an environment variable (`core/lib/kv/index.ts`). [[1]](diffhunk://#diff-b1410a54099d56f70b523df52ab2172d91508381035e573612d7ad5316407681R112-R117) [[2]](diffhunk://#diff-b1410a54099d56f70b523df52ab2172d91508381035e573612d7ad5316407681L106-R139)
* Added a `setRequest` method to the `KvAdapter` interface to support request handling (`core/lib/kv/types.ts`).

### Middleware Updates:

* Updated the `withRoutes` middleware to create and use a `KV` instance with the current request (`core/middlewares/with-routes.ts`). [[1]](diffhunk://#diff-fb9cfefddb5920bd983d193be75fdf2cf75455e3e42f28cffc500c6f72997a61R9-R11) [[2]](diffhunk://#diff-fb9cfefddb5920bd983d193be75fdf2cf75455e3e42f28cffc500c6f72997a61R173) [[3]](diffhunk://#diff-fb9cfefddb5920bd983d193be75fdf2cf75455e3e42f28cffc500c6f72997a61R188) [[4]](diffhunk://#diff-fb9cfefddb5920bd983d193be75fdf2cf75455e3e42f28cffc500c6f72997a61L211-R214) [[5]](diffhunk://#diff-fb9cfefddb5920bd983d193be75fdf2cf75455e3e42f28cffc500c6f72997a61L226-R237) [[6]](diffhunk://#diff-fb9cfefddb5920bd983d193be75fdf2cf75455e3e42f28cffc500c6f72997a61R260-R263)